### PR TITLE
Import psp ram extend patches from Adrenaline

### DIFF
--- a/kern/CMakeLists.txt
+++ b/kern/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(NoPspEmuDrm_kern
   RifPatch.c
   CompatPatch.c
   EbootSigPatch.c
+  HighMem.c
 )
 
 target_link_libraries(NoPspEmuDrm_kern

--- a/kern/CMakeLists.txt
+++ b/kern/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(NoPspEmuDrm_kern
   SceSysclibForDriver_stub
   SceDebugForDriver_stub
   SceThreadmgrForDriver_stub
+  SceSysmemForDriver_stub
 )
 
 vita_create_self(NoPspEmuDrm_kern.skprx NoPspEmuDrm_kern CONFIG exports.yml UNSAFE)

--- a/kern/HighMem.c
+++ b/kern/HighMem.c
@@ -1,0 +1,121 @@
+// NoPspEmuDrm 
+// Created by Li, based on NoNpDrm kernel plugin
+
+// highmem routines imported from Adrenaline
+
+// below is the copyright notice for the original NoNpDrm :
+
+/*
+  NoNpDrm Plugin
+  Copyright (C) 2017-2018, TheFloW
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// below is the copyright notice for the original Adrenaline :
+
+/*
+  Adrenaline
+  Copyright (C) 2016-2018, TheFloW
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <vitasdkkern.h>
+#include <taihen.h>
+#include <psp2kern/kernel/sysmem.h>
+
+#include "Log.h"
+
+static SceUID extra_1_blockid = -1;
+static SceUID extra_2_blockid = -1;
+static SceUID mem_hooks[4];
+
+static tai_hook_ref_t ksceKernelAllocMemBlockRef;
+static tai_hook_ref_t ksceKernelFreeMemBlockRef;
+static tai_hook_ref_t ksceKernelUnmapMemBlockRef;
+static tai_hook_ref_t SceGrabForDriver_E9C25A28_ref;
+
+static SceUID ksceKernelAllocMemBlockPatched(const char *name, SceKernelMemBlockType type, int size, SceKernelAllocMemBlockKernelOpt *optp) {
+	SceUID blockid = TAI_CONTINUE(SceUID, ksceKernelAllocMemBlockRef, name, type, size, optp);
+
+	uint32_t addr;
+	ksceKernelGetMemBlockBase(blockid, (void *)&addr);
+
+	if (addr == 0x23000000) {
+		extra_1_blockid = blockid;
+	} else if (addr == 0x24000000) {
+		extra_2_blockid = blockid;
+	}
+
+	return blockid;
+}
+
+static int ksceKernelFreeMemBlockPatched(SceUID uid) {
+	if (uid == extra_1_blockid){
+		log("%s: blocked releasing of extra_1\n", __func__);
+		return 0;
+	}
+
+	int res = TAI_CONTINUE(int, ksceKernelFreeMemBlockRef, uid);
+
+	if (uid == extra_2_blockid) {
+		ksceKernelFreeMemBlock(extra_1_blockid);
+		extra_1_blockid = -1;
+		extra_2_blockid = -1;
+		log("%s: released both extra_1 and extra_2\n", __func__);
+	}
+
+	return res;
+}
+
+static int ksceKernelUnmapMemBlockPatched(SceUID uid) {
+	return 0;
+}
+
+static int SceGrabForDriver_E9C25A28_patched(int unk, uint32_t paddr) {
+	log("%s: %d 0x%x\n", __func__, unk, paddr);
+
+	if (unk == 2 && paddr == 0x21000001){
+		log("%s: overriding address 0x%x to 0x%x\n", __func__, 0x21000001, 0x22000001);
+		paddr = 0x22000001;
+	}
+
+	return TAI_CONTINUE(int, SceGrabForDriver_E9C25A28_ref, unk, paddr);
+}
+
+void init_highmem(){
+	mem_hooks[0] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelAllocMemBlockRef, "SceCompat", 0x6F25E18A, 0xC94850C9, ksceKernelAllocMemBlockPatched);
+	mem_hooks[1] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelFreeMemBlockRef, "SceCompat", 0x6F25E18A, 0x009E1C61, ksceKernelFreeMemBlockPatched);
+	mem_hooks[2] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelUnmapMemBlockRef, "SceCompat", 0x6F25E18A, 0xFFCD9B60, ksceKernelUnmapMemBlockPatched);
+	mem_hooks[3] = taiHookFunctionImportForKernel(KERNEL_PID, &SceGrabForDriver_E9C25A28_ref, "SceCompat", 0x81C54BED, 0xE9C25A28, SceGrabForDriver_E9C25A28_patched);
+}
+
+void term_highmem(){
+	taiHookReleaseForKernel(mem_hooks[0], ksceKernelAllocMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[1], ksceKernelFreeMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[2], ksceKernelUnmapMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[3], SceGrabForDriver_E9C25A28_ref);
+}

--- a/kern/HighMem.h
+++ b/kern/HighMem.h
@@ -1,0 +1,5 @@
+#ifndef __HIGHMEM_H__
+#define __HIGHMEM_H__
+void init_highmem();
+void term_highmem();
+#endif

--- a/kern/Main.c
+++ b/kern/Main.c
@@ -23,12 +23,64 @@
 
 #include <vitasdkkern.h>
 #include <taihen.h>
+#include <psp2kern/kernel/sysmem.h>
 
 // pull in my rif struct from user plugin 
 #include "EcPatch.h"
 #include "RifPatch.h"
 #include "CompatPatch.h"
 #include "EbootSigPatch.h"
+
+static SceUID extra_1_blockid = -1;
+static SceUID extra_2_blockid = -1;
+static SceUID mem_hooks[4];
+
+static tai_hook_ref_t ksceKernelAllocMemBlockRef;
+static tai_hook_ref_t ksceKernelFreeMemBlockRef;
+static tai_hook_ref_t ksceKernelUnmapMemBlockRef;
+static tai_hook_ref_t SceGrabForDriver_E9C25A28_ref;
+
+static SceUID ksceKernelAllocMemBlockPatched(const char *name, SceKernelMemBlockType type, int size, SceKernelAllocMemBlockKernelOpt *optp) {
+	SceUID blockid = TAI_CONTINUE(SceUID, ksceKernelAllocMemBlockRef, name, type, size, optp);
+
+	uint32_t addr;
+	ksceKernelGetMemBlockBase(blockid, (void *)&addr);
+
+	if (addr == 0x23000000) {
+		extra_1_blockid = blockid;
+	} else if (addr == 0x24000000) {
+		extra_2_blockid = blockid;
+	}
+
+	return blockid;
+}
+
+static int ksceKernelFreeMemBlockPatched(SceUID uid) {
+	if (uid == extra_1_blockid)
+		return 0;
+
+	int res = TAI_CONTINUE(int, ksceKernelFreeMemBlockRef, uid);
+
+	if (uid == extra_2_blockid) {
+		ksceKernelFreeMemBlock(extra_1_blockid);
+		extra_1_blockid = -1;
+		extra_2_blockid = -1;
+	}
+
+	return res;
+}
+
+static int ksceKernelUnmapMemBlockPatched(SceUID uid) {
+	return 0;
+}
+
+static int SceGrabForDriver_E9C25A28_patched(int unk, uint32_t paddr) {
+	if (unk == 2 && paddr == 0x21000001)
+		paddr = 0x22000001;
+
+	return TAI_CONTINUE(int, SceGrabForDriver_E9C25A28_ref, unk, paddr);
+}
+
 
 void _start() __attribute__ ((weak, alias("module_start")));
 int module_start(SceSize args, void *argp) {	
@@ -41,6 +93,11 @@ int module_start(SceSize args, void *argp) {
 	init_compat_patch();
 	// Patch rif and act.dat signature checks, so the vita thinks our licenses are *LEGIT* -- makes manual work
 	init_ec_patch();
+
+	mem_hooks[0] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelAllocMemBlockRef, "SceCompat", 0x6F25E18A, 0xC94850C9, ksceKernelAllocMemBlockPatched);
+	mem_hooks[1] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelFreeMemBlockRef, "SceCompat", 0x6F25E18A, 0x009E1C61, ksceKernelFreeMemBlockPatched);
+	mem_hooks[2] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelUnmapMemBlockRef, "SceCompat", 0x6F25E18A, 0xFFCD9B60, ksceKernelUnmapMemBlockPatched);
+	mem_hooks[3] = taiHookFunctionImportForKernel(KERNEL_PID, &SceGrabForDriver_E9C25A28_ref, "SceCompat", 0x81C54BED, 0xE9C25A28, SceGrabForDriver_E9C25A28_patched);
 	
 	return SCE_KERNEL_START_SUCCESS;
 }
@@ -51,6 +108,11 @@ int module_stop(SceSize args, void *argp) {
 	term_eboot_sig_patch();
 	term_compat_patch();
 	term_ec_patch();
-		
+
+	taiHookReleaseForKernel(mem_hooks[0], ksceKernelAllocMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[1], ksceKernelFreeMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[2], ksceKernelUnmapMemBlockRef);
+	taiHookReleaseForKernel(mem_hooks[3], SceGrabForDriver_E9C25A28_ref);
+
 	return SCE_KERNEL_STOP_SUCCESS;
 }

--- a/kern/Main.c
+++ b/kern/Main.c
@@ -23,64 +23,13 @@
 
 #include <vitasdkkern.h>
 #include <taihen.h>
-#include <psp2kern/kernel/sysmem.h>
 
 // pull in my rif struct from user plugin 
 #include "EcPatch.h"
 #include "RifPatch.h"
 #include "CompatPatch.h"
 #include "EbootSigPatch.h"
-
-static SceUID extra_1_blockid = -1;
-static SceUID extra_2_blockid = -1;
-static SceUID mem_hooks[4];
-
-static tai_hook_ref_t ksceKernelAllocMemBlockRef;
-static tai_hook_ref_t ksceKernelFreeMemBlockRef;
-static tai_hook_ref_t ksceKernelUnmapMemBlockRef;
-static tai_hook_ref_t SceGrabForDriver_E9C25A28_ref;
-
-static SceUID ksceKernelAllocMemBlockPatched(const char *name, SceKernelMemBlockType type, int size, SceKernelAllocMemBlockKernelOpt *optp) {
-	SceUID blockid = TAI_CONTINUE(SceUID, ksceKernelAllocMemBlockRef, name, type, size, optp);
-
-	uint32_t addr;
-	ksceKernelGetMemBlockBase(blockid, (void *)&addr);
-
-	if (addr == 0x23000000) {
-		extra_1_blockid = blockid;
-	} else if (addr == 0x24000000) {
-		extra_2_blockid = blockid;
-	}
-
-	return blockid;
-}
-
-static int ksceKernelFreeMemBlockPatched(SceUID uid) {
-	if (uid == extra_1_blockid)
-		return 0;
-
-	int res = TAI_CONTINUE(int, ksceKernelFreeMemBlockRef, uid);
-
-	if (uid == extra_2_blockid) {
-		ksceKernelFreeMemBlock(extra_1_blockid);
-		extra_1_blockid = -1;
-		extra_2_blockid = -1;
-	}
-
-	return res;
-}
-
-static int ksceKernelUnmapMemBlockPatched(SceUID uid) {
-	return 0;
-}
-
-static int SceGrabForDriver_E9C25A28_patched(int unk, uint32_t paddr) {
-	if (unk == 2 && paddr == 0x21000001)
-		paddr = 0x22000001;
-
-	return TAI_CONTINUE(int, SceGrabForDriver_E9C25A28_ref, unk, paddr);
-}
-
+#include "HighMem.h"
 
 void _start() __attribute__ ((weak, alias("module_start")));
 int module_start(SceSize args, void *argp) {	
@@ -93,11 +42,8 @@ int module_start(SceSize args, void *argp) {
 	init_compat_patch();
 	// Patch rif and act.dat signature checks, so the vita thinks our licenses are *LEGIT* -- makes manual work
 	init_ec_patch();
-
-	mem_hooks[0] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelAllocMemBlockRef, "SceCompat", 0x6F25E18A, 0xC94850C9, ksceKernelAllocMemBlockPatched);
-	mem_hooks[1] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelFreeMemBlockRef, "SceCompat", 0x6F25E18A, 0x009E1C61, ksceKernelFreeMemBlockPatched);
-	mem_hooks[2] = taiHookFunctionImportForKernel(KERNEL_PID, &ksceKernelUnmapMemBlockRef, "SceCompat", 0x6F25E18A, 0xFFCD9B60, ksceKernelUnmapMemBlockPatched);
-	mem_hooks[3] = taiHookFunctionImportForKernel(KERNEL_PID, &SceGrabForDriver_E9C25A28_ref, "SceCompat", 0x81C54BED, 0xE9C25A28, SceGrabForDriver_E9C25A28_patched);
+	// Enable extra PSP memory
+	init_highmem();
 	
 	return SCE_KERNEL_START_SUCCESS;
 }
@@ -108,11 +54,7 @@ int module_stop(SceSize args, void *argp) {
 	term_eboot_sig_patch();
 	term_compat_patch();
 	term_ec_patch();
-
-	taiHookReleaseForKernel(mem_hooks[0], ksceKernelAllocMemBlockRef);
-	taiHookReleaseForKernel(mem_hooks[1], ksceKernelFreeMemBlockRef);
-	taiHookReleaseForKernel(mem_hooks[2], ksceKernelUnmapMemBlockRef);
-	taiHookReleaseForKernel(mem_hooks[3], SceGrabForDriver_E9C25A28_ref);
+	term_highmem();
 
 	return SCE_KERNEL_STOP_SUCCESS;
 }


### PR DESCRIPTION
This should allow downstream pspemu homebrews, like ARK standalone, to use up to 40MB partition 2 memory when desired

Homebrews will still have to patch the allocation on the PSP side, of course